### PR TITLE
Add options to configure the pool of connections and queue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,10 @@
 use Mix.Config
 
 config :media_works,
-  api_client: MediaWorks.HTTP
+  api_client: MediaWorks.HTTP,
+  remote_ordering_sessions: 100,
+  remote_ordering_pipeline: 100,
+  remote_ordering_url: "https://remote-ordering-dot-mw-central.appspot.com/",
+  api_url: "https://mw-central.appspot.com/"
 
 import_config "#{Mix.env}.exs"

--- a/lib/media_works.ex
+++ b/lib/media_works.ex
@@ -1,2 +1,30 @@
 defmodule MediaWorks do
+  use Application
+  alias MediaWorks.Config
+  @name __MODULE__
+
+  def start(_type, _args) do
+    import Supervisor.Spec, warn: false
+
+    # Start our app specific config
+    configure_remote_ordering_host
+
+    Supervisor.start_link([], [strategy: :one_for_one, name: @name])
+  end
+
+  def configure_remote_ordering_host do
+    {host, port} = parse_remote_ordering_url
+
+    :ibrowse.set_max_sessions(host, port, Config.remote_ordering_sessions)
+    :ibrowse.set_max_pipeline_size(host, port, Config.remote_ordering_pipeline)
+  end
+
+  defp parse_remote_ordering_url do
+    URI.parse(Config.remote_ordering_url)
+    |> case do
+      %{host: host, port: port} ->
+        {host |> String.to_charlist, port}
+    end
+  end
+
 end

--- a/lib/media_works/api.ex
+++ b/lib/media_works/api.ex
@@ -36,11 +36,6 @@ defmodule MediaWorks.API do
   end
   defdelegate get_datapump(params), to: @client
 
-  def send_order(store_id, %MediaWorks.Order{} = order) do
-    order = order |> MediaWorks.Order.to_remote
-    @client.send_order(store_id, order)
-  end
-
   def send_order(store_id, order) do
     @client.send_order(store_id, order)
   end

--- a/lib/media_works/api/http_client.ex
+++ b/lib/media_works/api/http_client.ex
@@ -3,8 +3,6 @@ defmodule MediaWorks.API.HTTPClient do
   alias MediaWorks.Config
   # 10 minutes in milliseconds
   @timeout (60 * 10) * 1000
-  @default_api_url "https://mw-central.appspot.com/"
-  @remote_ordering_url "https://remote-ordering-dot-mw-central.appspot.com/"
   @remote_ordering "remote_ordering"
   @headers [
     "Accept": "application/json",
@@ -13,8 +11,8 @@ defmodule MediaWorks.API.HTTPClient do
 
   def process_url(url) do
     case remote_ordering?(url)do
-      true -> @remote_ordering_url <> url
-      _ -> @default_api_url <> url
+      true -> Config.remote_ordering_url <> url
+      _ -> Config.api_url <> url
     end
   end
 

--- a/lib/media_works/config.ex
+++ b/lib/media_works/config.ex
@@ -19,6 +19,22 @@ defmodule MediaWorks.Config do
     |> check_value
   end
 
+  def remote_ordering_sessions do
+    Application.get_env(:media_works, :remote_ordering_sessions)
+  end
+
+  def remote_ordering_pipeline do
+    Application.get_env(:media_works, :remote_ordering_pipeline)
+  end
+
+  def remote_ordering_url do
+    Application.get_env(:media_works, :remote_ordering_url)
+  end
+
+  def api_url do
+    Application.get_env(:media_works, :api_url)
+  end
+
   defp check_value(nil) do
     raise ArgumentError, message: "Invalid config value given"
   end

--- a/lib/media_works/send_order_response.ex
+++ b/lib/media_works/send_order_response.ex
@@ -3,5 +3,5 @@ defmodule MediaWorks.SendOrderResponse do
   @valid_response_codes [0, 2]
 
   def success?(%{code: code}) when code in @valid_response_codes, do: true
-  def success?(%{code: code}), do: false
+  def success?(%{code: _}), do: false
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule MediaWorks.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [applications: [:logger, :httpotion]]
+    [applications: [:logger, :httpotion],
+     mod: {MediaWorks, []}]
   end
 
   # Dependencies can be Hex packages:


### PR DESCRIPTION
We now start MediaWorks as an application on boot, and then configure it with specific values.

By default `remote_ordering_sessions` and `remote_ordering_pipeline` are set to 100 each. 